### PR TITLE
Get user keys function updated

### DIFF
--- a/src/Guzzle3/TyrService.php
+++ b/src/Guzzle3/TyrService.php
@@ -188,7 +188,11 @@ class TyrService extends AbstractTyrService
      */
     public function getUserKeys($userId)
     {
-        $response = $this->client->get('users/'.$userId.'/keys')->send();
+        try {
+            $response = $this->client->get('users/'.$userId.'/keys')->send();
+        } catch (\Guzzle\Http\Exception\CurlException $ex) {
+            return null;
+        }
 
         return json_decode($response->getBody());
     }

--- a/src/TyrService.php
+++ b/src/TyrService.php
@@ -199,7 +199,11 @@ class TyrService extends AbstractTyrService
      */
     public function getUserKeys($userId)
     {
-        $response = $this->client->get('users/'.$userId.'/keys');
+        try {
+            $response = $this->client->get('users/'.$userId.'/keys');
+        } catch (\Guzzle\Http\Exception\CurlException $ex) {
+            return null;
+        }
 
         return json_decode($response->getBody());
     }


### PR DESCRIPTION
# Introduction

Return null when tyr api is down or when request is incorrect (only for getUserKeys function).