### PR TITLE
changed name of guzzle package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,10 +7,13 @@
     "keywords": ["php", "tyr"],
     "require": {
         "php": ">=5.2",
-        "guzzlehttp/guzzle": "~3.0|~5.0"
+        "guzzle/guzzle": "^3.8.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.3"
+    },
+    "suggest": {
+        "guzzlehttp/guzzle": ">=5.0 <6.0"
     },
     "autoload": {
         "psr-4": { "CanalTP\\TyrComponent\\": "src/" }


### PR DESCRIPTION
# Description

Change name of guzzle package in composer.json to be able to install guzzle >=5.0 (guzzlehttp/guzzle": "~5.0") and upgrade easily

# Pull Request type (optional)

This is a fix