### PR TITLE
Add error handling when a token cannot be created

### DIFF
--- a/src/Exception/InvalidApplicationNameException.php
+++ b/src/Exception/InvalidApplicationNameException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace CanalTP\TyrComponent\Exception;
+
+
+class InvalidApplicationNameException extends \LogicException
+{
+    public function __construct($previous = null)
+    {
+        parent::__construct("Application name is not valid", 0, $previous);
+    }
+}

--- a/src/Guzzle3/TyrService.php
+++ b/src/Guzzle3/TyrService.php
@@ -2,6 +2,7 @@
 
 namespace CanalTP\TyrComponent\Guzzle3;
 
+use CanalTP\TyrComponent\Exception\InvalidApplicationNameException;
 use Guzzle\Common\Event;
 use Guzzle\Http\Message\Response;
 use Guzzle\Service\Client;
@@ -172,6 +173,16 @@ class TyrService extends AbstractTyrService
         ))->send();
 
         $result = json_decode($response->getBody());
+
+        // only one error can have a 400 status code: invalid application name
+        if (400 === $response->getStatusCode()) {
+            if (!empty($result->message->app_name)) {
+                throw new InvalidApplicationNameException();
+            }
+
+            throw new \LogicException('An error occured while trying to create a token');
+        }
+
         $key = null;
 
         if (is_object($result) && property_exists($result, 'keys') && is_array($result->keys)) {

--- a/src/TyrService.php
+++ b/src/TyrService.php
@@ -2,6 +2,7 @@
 
 namespace CanalTP\TyrComponent;
 
+use CanalTP\TyrComponent\Exception\InvalidApplicationNameException;
 use Guzzle\Http\Message\Response;
 use GuzzleHttp\Client;
 use GuzzleHttp\Event\CompleteEvent;
@@ -183,6 +184,16 @@ class TyrService extends AbstractTyrService
         ));
 
         $result = json_decode($response->getBody());
+
+        // only one error can have a 400 status code: invalid application name
+        if (400 === $response->getStatusCode()) {
+            if (!empty($result->message->app_name)) {
+                throw new InvalidApplicationNameException();
+            }
+
+            throw new \LogicException('An error occured while trying to create a token');
+        }
+
         $key = null;
 
         if (is_object($result) && property_exists($result, 'keys') && is_array($result->keys)) {

--- a/tests/TyrServiceTest.php
+++ b/tests/TyrServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace CanalTP\TyrComponent\Tests;
 
+use CanalTP\TyrComponent\Exception\InvalidApplicationNameException;
 use CanalTP\TyrComponent\VersionChecker;
 
 class TyrServiceTest extends \PHPUnit_Framework_TestCase
@@ -291,6 +292,15 @@ class TyrServiceTest extends \PHPUnit_Framework_TestCase
         $this->tyrService->deleteBillingPlan($createdPlan->id);
 
         $this->assertEquals(404, $this->tyrService->getLastResponse()->getStatusCode());
+    }
+
+    /**
+     * @expectedException CanalTP\TyrComponent\Exception\InvalidApplicationNameException
+     * @expectedExceptionMessage Application name is not valid
+     */
+    public function testCreateTokenWithInvalidCharShouldFail()
+    {
+        $this->tyrService->createUserKey(1337, 'invalid app namé');
     }
 
     /**


### PR DESCRIPTION
# Description
When you create a token with an invalid character, nothing happened and you did not know what was wrong.

I added an error handling, now, you will have an exception thrown when the response status code is 400.
A new unit test handles now this case.

# How to test
- Launch tests: `vendor/bin/phpunit -c .`